### PR TITLE
Update imports for use in Python3.10+

### DIFF
--- a/gmatch4py/embedding/deepwalk.pyx
+++ b/gmatch4py/embedding/deepwalk.pyx
@@ -26,8 +26,8 @@ import psutil
 
 cimport cython
 from ..base cimport Base
-import graph as graph2
-import walks as serialized_walks
+import gmatch4py.embedding.graph as graph2
+import gmatch4py.embedding.walks as serialized_walks
 from .skipgram import Skipgram
 
 

--- a/gmatch4py/embedding/graph.pyx
+++ b/gmatch4py/embedding/graph.pyx
@@ -11,7 +11,13 @@ from time import time
 from glob import glob
 from six.moves import range, zip, zip_longest
 from six import iterkeys
-from collections import defaultdict, Iterable
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+from collections import defaultdict
+
 import random
 from random import shuffle
 from itertools import product,permutations

--- a/gmatch4py/embedding/skipgram.pyx
+++ b/gmatch4py/embedding/skipgram.pyx
@@ -1,8 +1,5 @@
-from collections import Counter, Mapping
-from concurrent.futures import ProcessPoolExecutor
 import logging
 from multiprocessing import cpu_count
-from six import string_types
 
 from gensim.models import Word2Vec
 


### PR DESCRIPTION
Closes https://github.com/Jacobe2169/GMatch4py/issues/34, since I assume they were on Python3.10 which is the default for Ubuntu 22